### PR TITLE
script run default duration

### DIFF
--- a/lib/plunketts/scripts/script_executer.rb
+++ b/lib/plunketts/scripts/script_executer.rb
@@ -25,7 +25,7 @@ class ScriptExecutor
   # returns a ScriptRun object describing the run
   def run(stream)
     @stream = stream
-    script_run = ScriptRun.new script_id: @script.id, created_at: Time.now
+    script_run = ScriptRun.new script_id: @script.id, created_at: Time.now, duration: 0
     t = Time.now
     begin
       escaped_body = @script.body.gsub('\"', '"')


### PR DESCRIPTION
Prevent exception when saving the run by setting the duration to 0 in the .new call.