### PR TITLE
Add QueryResult as a valid CSV type

### DIFF
--- a/lib/plunketts/io/cvs_io.rb
+++ b/lib/plunketts/io/cvs_io.rb
@@ -154,7 +154,7 @@ module CsvIo
         options[:columns] = _data.length > 0 ? _data.first.keys : []
         CsvIo.create_sheet book, _data, options
       end
-    elsif data.is_a?(Array)
+    elsif data.is_a?(Array) || data.is_a?(QueryResult)
       CsvIo.create_sheet book, data, options
     else
       raise 'Unknown Data Type'


### PR DESCRIPTION
I noticed after you added class validation to the save_xls file, several scripts stopped working.  I think we need to allow QueryResults to be directly dumped to xls.  Not sure if this is he best way to fix this, so you can decide.