### PR TITLE
show script fields on the script run history page

### DIFF
--- a/app/assets/javascripts/plunketts/scripts.coffee
+++ b/app/assets/javascripts/plunketts/scripts.coffee
@@ -1109,6 +1109,7 @@ _runsTemplate = tinyTemplate (runs) ->
 					th '', 'User'
 					th '', 'Duration'
 					th '', 'Status'
+					th '', 'Run Options'
 					th '', 'Exception'
 					th ''
 			tbody '', ->
@@ -1119,6 +1120,7 @@ _runsTemplate = tinyTemplate (runs) ->
 						td '', run.created_by_name
 						td '', "#{(run.duration || 0).toFixed(1)}s"
 						td ".status.#{run.status}", run.status.titleize()
+						td '', "#{JSON.stringify(run.fields) || ''}"
 						td '.exception', run.exception || ''
 						td '.inline-actions', ->
 							a '.with-icon', href: run.log_url, target: '_blank', ->

--- a/lib/plunketts/scripts/script_executer.rb
+++ b/lib/plunketts/scripts/script_executer.rb
@@ -26,7 +26,7 @@ class ScriptExecutor
   # returns a ScriptRun object describing the run
   def run(stream)
     @stream = stream
-    script_run = ScriptRun.new script_id: @script.id, created_at: Time.now, duration: 0
+    script_run = ScriptRun.new script_id: @script.id, created_at: Time.now, duration: 0, fields: @field_values
     t = Time.now
     begin
       escaped_body = @script.body.gsub('\"', '"')


### PR DESCRIPTION
This makes it much easier for admins to see which parameters were run for a specific script run history.  I've printed them as simple stringified JSON for now.